### PR TITLE
Add dark mode theme toggle

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,7 +15,8 @@
   document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';
 </script>
 
-<!-- For all browsers -->
-<link rel="stylesheet" href="{{ base_path }}/assets/css/main.css">
+  <!-- For all browsers -->
+  <link rel="stylesheet" href="{{ base_path }}/assets/css/main.css">
+  <link rel="stylesheet" href="{{ base_path }}/assets/css/dark-mode.css">
 
-<meta http-equiv="cleartype" content="on">
+  <meta http-equiv="cleartype" content="on">

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,3 +1,4 @@
+<script src="{{ base_path }}/assets/js/dark-mode.js"></script>
 <script src="{{ base_path }}/assets/js/main.min.js"></script>
 
 {% include analytics.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,21 +11,22 @@ layout: compress
     {% include head/custom.html %}
   </head>
 
-  <body>
+    <body>
 
-    {% include browser-upgrade.html %}
-    {% include masthead.html %}
+      {% include browser-upgrade.html %}
+      {% include masthead.html %}
+      <button id="theme-toggle" class="btn" aria-label="Toggle dark mode">🌓</button>
 
-    {{ content }}
+      {{ content }}
 
-    <div class="page__footer">
-      <footer>
-        {% include footer/custom.html %}
-        {% include footer.html %}
-      </footer>
-    </div>
+      <div class="page__footer">
+        <footer>
+          {% include footer/custom.html %}
+          {% include footer.html %}
+        </footer>
+      </div>
 
-    {% include scripts.html %}
+      {% include scripts.html %}
 
-  </body>
+    </body>
 </html>

--- a/assets/css/dark-mode.scss
+++ b/assets/css/dark-mode.scss
@@ -1,0 +1,16 @@
+---
+---
+
+// Dark theme overrides
+[data-theme="dark"] {
+  background-color: #121212;
+  color: #f0f0f0;
+}
+
+[data-theme="dark"] a {
+  color: #8ab4f8;
+}
+
+[data-theme="dark"] .page__footer {
+  background-color: #1e1e1e;
+}

--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -1,0 +1,21 @@
+(function() {
+  const storageKey = 'theme';
+  const toggle = document.getElementById('theme-toggle');
+
+  const setTheme = theme => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem(storageKey, theme);
+  };
+
+  const stored = localStorage.getItem(storageKey);
+  if (stored) {
+    document.documentElement.setAttribute('data-theme', stored);
+  }
+
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      const current = document.documentElement.getAttribute('data-theme') === 'dark';
+      setTheme(current ? 'light' : 'dark');
+    });
+  }
+})();


### PR DESCRIPTION
## Summary
- add dark-mode stylesheet and load it in the site head
- include a theme toggle button and script to persist preference

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*
- `bundle install` *(fails: 403 Forbidden fetching gems)*
- `npm run build:js` *(fails: uglifyjs: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a838bd3518832dbc17abdb1041c5c2