### PR TITLE
Improve dark mode toggle placement and contrast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site/
+node_modules/
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,7 +15,8 @@
   document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/g, '') + ' js ';
 </script>
 
-<!-- For all browsers -->
-<link rel="stylesheet" href="{{ base_path }}/assets/css/main.css">
+  <!-- For all browsers -->
+  <link rel="stylesheet" href="{{ base_path }}/assets/css/main.css">
+  <link rel="stylesheet" href="{{ base_path }}/assets/css/dark-mode.css">
 
-<meta http-equiv="cleartype" content="on">
+  <meta http-equiv="cleartype" content="on">

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -13,8 +13,9 @@
               {% else %}
               {% assign domain = base_path %}
             {% endif %}
-            <li class="masthead__menu-item"><a href="{{ domain }}{{ link.url }}">{{ link.title }}</a></li>
-          {% endfor %}
+          <li class="masthead__menu-item"><a href="{{ domain }}{{ link.url }}">{{ link.title }}</a></li>
+        {% endfor %}
+        <li class="masthead__menu-item theme-toggle"><button id="theme-toggle" class="btn" aria-label="Toggle dark mode">🌓</button></li>
         </ul>
         <ul class="hidden-links hidden"></ul>
       </nav>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,3 +1,4 @@
+<script src="{{ base_path }}/assets/js/dark-mode.js"></script>
 <script src="{{ base_path }}/assets/js/main.min.js"></script>
 
 {% include analytics.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,21 +11,21 @@ layout: compress
     {% include head/custom.html %}
   </head>
 
-  <body>
+    <body>
 
-    {% include browser-upgrade.html %}
-    {% include masthead.html %}
+      {% include browser-upgrade.html %}
+      {% include masthead.html %}
 
-    {{ content }}
+      {{ content }}
 
-    <div class="page__footer">
-      <footer>
-        {% include footer/custom.html %}
-        {% include footer.html %}
-      </footer>
-    </div>
+      <div class="page__footer">
+        <footer>
+          {% include footer/custom.html %}
+          {% include footer.html %}
+        </footer>
+      </div>
 
-    {% include scripts.html %}
+      {% include scripts.html %}
 
-  </body>
+    </body>
 </html>

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -189,7 +189,7 @@
     }
   }
 
-  button {
+  > button {
     position: absolute;
     height: 100%;
     right: 0;
@@ -201,11 +201,21 @@
     cursor: pointer;
   }
 
+  .theme-toggle button {
+    background: none;
+    border: 0;
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    padding: 0;
+  }
+
   .visible-links {
-    display: table;
+    display: flex;
+    align-items: center;
 
     li {
-      display: table-cell;
+      display: block;
       vertical-align: middle;
 
       &:first-child {
@@ -220,6 +230,10 @@
         a {
           margin-right: 0;
         }
+      }
+
+      &.theme-toggle {
+        margin-left: auto;
       }
     }
 

--- a/assets/css/dark-mode.scss
+++ b/assets/css/dark-mode.scss
@@ -1,0 +1,27 @@
+---
+---
+
+// Dark theme overrides
+[data-theme="dark"] {
+  background-color: #121212;
+  color: #e0e0e0;
+}
+
+[data-theme="dark"] a {
+  color: #8ab4f8;
+}
+
+[data-theme="dark"] .masthead,
+[data-theme="dark"] .greedy-nav,
+[data-theme="dark"] .page__footer {
+  background-color: #1e1e1e;
+  color: #e0e0e0;
+}
+
+[data-theme="dark"] .greedy-nav a {
+  color: #e0e0e0;
+}
+
+[data-theme="dark"] .greedy-nav a:hover {
+  color: #ffffff;
+}

--- a/assets/js/dark-mode.js
+++ b/assets/js/dark-mode.js
@@ -1,0 +1,21 @@
+(function() {
+  const storageKey = 'theme';
+  const toggle = document.getElementById('theme-toggle');
+
+  const setTheme = theme => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem(storageKey, theme);
+  };
+
+  const stored = localStorage.getItem(storageKey);
+  if (stored) {
+    document.documentElement.setAttribute('data-theme', stored);
+  }
+
+  if (toggle) {
+    toggle.addEventListener('click', () => {
+      const current = document.documentElement.getAttribute('data-theme') === 'dark';
+      setTheme(current ? 'light' : 'dark');
+    });
+  }
+})();


### PR DESCRIPTION
## Summary
- Move theme toggle into the masthead and align it to the right alongside navigation links
- Refine navigation layout to support the toggle and ensure proper styling
- Expand dark mode palette for better contrast across masthead, footer, and links

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `npm run build:js`


------
https://chatgpt.com/codex/tasks/task_e_68a838bd3518832dbc17abdb1041c5c2