### PR TITLE
Move dark mode switch to navigation header

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -15,9 +15,13 @@
             {% endif %}
             <li class="masthead__menu-item"><a href="{{ domain }}{{ link.url }}">{{ link.title }}</a></li>
           {% endfor %}
+          <li class="masthead__menu-item">
+            <a id="theme-toggle" href="javascript:void(0)" role="button" aria-label="Toggle dark mode">🌓</a>
+          </li>
         </ul>
         <ul class="hidden-links hidden"></ul>
       </nav>
     </div>
   </div>
+
 </div>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -15,12 +15,10 @@
             {% endif %}
             <li class="masthead__menu-item"><a href="{{ domain }}{{ link.url }}">{{ link.title }}</a></li>
           {% endfor %}
-          <li class="masthead__menu-item">
-            <a id="theme-toggle" href="javascript:void(0)" role="button" aria-label="Toggle dark mode">🌓</a>
-          </li>
         </ul>
         <ul class="hidden-links hidden"></ul>
       </nav>
+      <a id="theme-toggle" class="masthead__menu-item theme-toggle" href="javascript:void(0)" role="button" aria-label="Toggle dark mode">🌓</a>
     </div>
   </div>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,6 @@ layout: compress
 
       {% include browser-upgrade.html %}
       {% include masthead.html %}
-      <button id="theme-toggle" class="btn" aria-label="Toggle dark mode">🌓</button>
 
       {{ content }}
 

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -32,12 +32,22 @@
 }
 
 .masthead__menu {
+  display: flex;
+  align-items: center;
+
+  nav {
+    flex: 1;
+  }
 
   ul {
     margin: 0;
     padding: 0;
     clear: both;
     list-style-type: none;
+  }
+
+  .theme-toggle {
+    margin-left: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- Show dark mode toggle alongside navigation links by moving it into the masthead menu
- Remove standalone dark mode button from default layout

## Testing
- `bundle exec jekyll build` *(fails: bundler can't find jekyll; attempted bundle install but got 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a85b24c944832da7ac37695a6d9fe4