### PR TITLE
feat: improve dark mode header and contrast

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -18,6 +18,27 @@
         </ul>
         <ul class="hidden-links hidden"></ul>
       </nav>
+      <button id="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle dark mode">
+        <span class="icon-sun" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="5" fill="currentColor" stroke="none"/>
+            <line x1="12" y1="1" x2="12" y2="3"/>
+            <line x1="12" y1="21" x2="12" y2="23"/>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+            <line x1="1" y1="12" x2="3" y2="12"/>
+            <line x1="21" y1="12" x2="23" y2="12"/>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+          </svg>
+        </span>
+        <span class="icon-moon" aria-hidden="true">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+            <circle cx="12" cy="12" r="10" fill="#121212"/>
+            <path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" fill="#ffffff"/>
+          </svg>
+        </span>
+      </button>
     </div>
   </div>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,6 @@ layout: compress
 
       {% include browser-upgrade.html %}
       {% include masthead.html %}
-      <button id="theme-toggle" class="btn" aria-label="Toggle dark mode">🌓</button>
 
       {{ content }}
 

--- a/assets/css/dark-mode.scss
+++ b/assets/css/dark-mode.scss
@@ -4,13 +4,67 @@
 // Dark theme overrides
 [data-theme="dark"] {
   background-color: #121212;
-  color: #f0f0f0;
+  color: #ffffff;
+}
+
+[data-theme="dark"] body {
+  color: #ffffff;
 }
 
 [data-theme="dark"] a {
   color: #8ab4f8;
 }
 
+[data-theme="dark"] .masthead {
+  background-color: #000000;
+  border-bottom: 1px solid #333333;
+  color: #ffffff;
+}
+
+[data-theme="dark"] .masthead a {
+  color: #ffffff;
+}
+
+[data-theme="dark"] .masthead a:hover {
+  color: #dddddd;
+}
+
 [data-theme="dark"] .page__footer {
   background-color: #1e1e1e;
+}
+
+/* Ensure masthead items stay on one line with toggle on the right */
+.masthead__menu {
+  display: flex;
+  align-items: center;
+}
+
+.masthead__menu nav {
+  flex-grow: 1;
+}
+
+#theme-toggle {
+  margin-left: auto;
+  background: transparent;
+  border: 0;
+  padding: 0.25em;
+  color: inherit;
+  cursor: pointer;
+}
+
+#theme-toggle svg {
+  width: 24px;
+  height: 24px;
+}
+
+#theme-toggle .icon-moon {
+  display: none;
+}
+
+[data-theme="dark"] #theme-toggle .icon-sun {
+  display: none;
+}
+
+[data-theme="dark"] #theme-toggle .icon-moon {
+  display: inline;
 }


### PR DESCRIPTION
## Summary
- make dark-mode masthead black with white links for better contrast
- switch overall dark theme text to bright white

## Testing
- `npm run build:js`
- `bundle exec jekyll build` *(fails: bundler: command not found)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a85eece794832d9854cff02e55390d